### PR TITLE
Avoid endless waiting in 'kubeadm reset' adding 'yes': 'yes | kubeadm…

### DIFF
--- a/kubernetes/roles/master/tasks/init.yml
+++ b/kubernetes/roles/master/tasks/init.yml
@@ -2,7 +2,7 @@
 - lineinfile: dest=/etc/sysctl.conf line='net.bridge.bridge-nf-call-iptables = 1' state=present
 - name: initialize kube
   shell: >
-       kubeadm reset &&
+       yes | kubeadm reset &&
        sysctl -p &&
        kubeadm init --apiserver-advertise-address=10.0.0.10 --pod-network-cidr=10.244.0.0/16
   args:

--- a/kubernetes/roles/nodes/tasks/main.yml
+++ b/kubernetes/roles/nodes/tasks/main.yml
@@ -8,7 +8,7 @@
   when: inventory_hostname == master_hostname
 - name: join nodes
   shell: >
-     systemctl stop kubelet ; kubeadm reset ; 
+     systemctl stop kubelet ; yes | kubeadm reset ; 
      echo "{{hostvars[master_hostname].kubeadm_join}}" >/etc/kubeadm-join.sh ; 
      bash /etc/kubeadm-join.sh
   args:


### PR DESCRIPTION
Fix hang on ansible-playbook site.yml.

Reproduce conditions:

Virtualbox: 5.1.38
ansible version: 2.7.1
kubeadm version: &version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.2", GitCommit:"17c77c7898218073f14c8d573582e8d2313dc740", GitTreeState:"clean", BuildDate:"2018-10-24T06:51:33Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}

Reproduce path:

cd servers/vbox
vagrant up
vagrant ssh-config >~/.ssh/config # yes, I reqrite config instead of appending
cd ../../kubernetes
ansible-playbook site.yml

Observed result:
hangs on 'TASK [master : initialize kube]'

Further investigation discovered that 'kubeadm reset' prompted for confirmation, expecting 'y' or 'yes'. After prepending 'kubeadm reset' with 'yes |' in couple of spots everything worked well